### PR TITLE
Proof of concept for HMF theory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Jetbrains
+.idea

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # cobaya-hacks
 Wrapping things as cobaya components
+
+Before using, make sure you run from your virtual environment 
+```.env
+pip install -e .
+```
+from the root directory. This will allow cobaya to find cobayahack components.
+
+

--- a/cobayahacks/theories/hmf/__init__.py
+++ b/cobayahacks/theories/hmf/__init__.py
@@ -1,0 +1,1 @@
+from .hmf import hmf

--- a/cobayahacks/theories/hmf/hmf.py
+++ b/cobayahacks/theories/hmf/hmf.py
@@ -1,0 +1,62 @@
+from cobaya.theory import Theory
+import numpy as np
+from hmf import MassFunction
+from astropy.cosmology import LambdaCDM, FLRW
+
+
+class hmf(Theory):
+    def initialize(self):
+        self._hmf_kwargs = {
+            'use_splined_growth': True
+        }
+        self._hmf_kwargs.update(self.hmf_kwargs)
+        self.quants = ['dndm', 'rho_gtm', 'ngtm', 'power', 'growth_factor']
+        self.input_params = ['omegabh2', 'omegach2', 'H0']
+
+    def needs(self, **requirements):
+        self._reqs = requirements.keys()
+
+    def get_can_provide(self):
+        return self.quants + ['MF']
+
+    def get_requirements(self):
+        print("Requirements")
+        return {
+            "Pk_grid": {
+                "z": self.zarr,
+                "k_max": 5.0,
+                "nonlinear": False,
+                "vars_pairs": [["delta_tot", "delta_tot"]],
+            },
+            "Hubble": {"z": self.zarr},
+            "angular_diameter_distance": {"z": self.zarr},
+        }
+
+    def initialize_with_params(self):
+        print("params")
+        pass
+
+    def calculate(self, state, want_derived=True, **params_values_dict):
+        self._hmf_kwargs['z'] = self.zarr[0]
+        h = params_values_dict["H0"] / 100
+        Oc = params_values_dict['omegach2'] / h**2
+        Ob = params_values_dict['omegabh2'] / h**2
+        Om = Oc + Ob
+        Ode = 1 - Om
+        self._hmf_kwargs['cosmo_params'] = {
+            'H0': 100*h,
+            'Om0': Om,
+            'Ob0': Ob,
+        }
+        self.MF = MassFunction(**self._hmf_kwargs)
+
+        for q in self.quants:
+            state[q] = []
+        for i, z in enumerate(self.zarr):
+            if i > 0:
+                self.MF.update(z=z)
+            for q in self.quants:
+                state[q].append(getattr(self.MF, q).copy())
+        state["MF"] = self.MF
+        state['zs'] = self.zarr
+

--- a/cobayahacks/theories/hmf/hmf.yaml
+++ b/cobayahacks/theories/hmf/hmf.yaml
@@ -1,0 +1,6 @@
+zarr: null
+hmf_kwargs: {}
+input_params:
+  - omegabh2
+  - omegach2
+  - H0

--- a/examples/hmf_example.py
+++ b/examples/hmf_example.py
@@ -1,0 +1,53 @@
+from cobaya.model import get_model
+import numpy as np
+from scipy import stats
+import matplotlib.pyplot as plt
+
+
+
+def fake_likelihood(
+        _theory={'dndm': None, 'power': None, "MF": None}):
+    dndm = _theory.get_result('dndm')
+    print(dndm[0])
+    return stats.norm.logpdf(0, loc=0, scale=0.1)
+
+
+fiducial_params = {
+    "omegabh2": 0.02225,
+    "omegach2": 0.1198,
+    "H0": 67.3,
+    "tau": 0.06,
+    "As": 2.2e-9,
+    "ns": 0.96,
+}
+
+zs = np.linspace(0, 2, 40)
+info = {
+    "debug": True,
+    "params": fiducial_params,
+    "likelihood": {
+        'test_likelihood': fake_likelihood
+    },
+    "theory": {
+        "classy": {
+            "extra_args": {}
+        },
+        "cobayahacks.theories.hmf": {
+            "zarr": zs,
+            "hmf_kwargs": {}
+        }
+    },
+}
+
+
+m = get_model(info)
+
+print(m.loglike())
+
+mf = m.provider.get_result("MF")
+power = m.provider.get_result("power")
+plt.plot(mf.k, power[0])
+plt.xscale('log')
+plt.yscale('log')
+plt.show()
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+setup(name='cobayahacks',
+      description='Custom cobaya components',
+      packages=['cobayahacks'])


### PR DESCRIPTION
Mostly just proof of concept for a custom hmf theory. 

Right now the hmf theory provides `dndm`, `rho_gtm`, `ngtm`, `power` (linear matter ps), `growth_factor`, and the MassFunction variable, which can be accessed from the model and likelihood. 

I played a little bit with setting the HMF cosmology parameters to be consistent the the input parameters, but haven't tested to see if the power spectrum matches the one provided by the theory, which would eventually be a good test to make sure all of the hmf cosmology is consistent.

`examples/hmf_example.py` shows how to use the hmf theory in conjunction with a boltzman code. 

It also adds some packaging via setup.py which seems to be necessary to get cobaya to find our components.